### PR TITLE
Fix hazard processing.

### DIFF
--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -6,6 +6,10 @@
 empty_hazard_fn <- function(property) {
     return (rep(0.5, length(property)))
 }
+# 0.7 return works out to approximately 50% chance
+fifty_fifty_hazard <- function(a) {
+    return (rep(0.7, length(a)))
+}
 #' Empty hazard transition function example
 #'
 #' @param a This value is directly returned

--- a/tests/testthat/test-hazard-transition.R
+++ b/tests/testthat/test-hazard-transition.R
@@ -15,15 +15,21 @@ library(eldoradosim)
 #
 
 
-transition_to_2 <- function(a) {
-    return (rep(2, length(a)))
+transition_add_2 <- function(a) {
+    return (a + 2)
+}
+transition_add_3 <- function(a) {
+    return (a + 3)
 }
 
 #' odd indices 0, even indices 1 (e.g. [0,1,0,1,0,1...])
 #' predictable nature makes it useful for testing hazards and transitions
+#' Hazards don't return direct chance, it's passed through 1-exp(-hazard)
+#' As such we set 1000, which is effectively 99.99% chance
+#' Small potential for this to cause test failures occasionally, so probably best to seed these tests
 yes_no_hazard <- function(a) {
     ret <- rep(0.0, length(a))
-    ret[seq(2, length(ret), by = 2)] <- 1.0
+    ret[seq(2, length(ret), by = 2)] <- 1000.0
     return (ret)
 }
 
@@ -35,14 +41,37 @@ get_parms <- function() {
               yes_no_hazard,
               c("a"),
               list(
-                new_transition(transition_to_2, c("a"), "a")
+                new_transition(transition_add_2, c("a"), "a")
               )
             )
           ),
           trajectories = list(
             new_trajectory(empty_trajectory_fn, c("b"), "b")
           ),
-          steps = 1
+          steps = 1,
+          random_seed = 12
+        )
+    )
+}
+get_parms2 <- function() {
+    # Dual transition
+    return(
+        parms <- new_parameters(
+          hazards = list(
+            new_hazard(
+              yes_no_hazard,
+              c("a"),
+              list(
+                new_transition(transition_add_2, c("a"), "a"),
+                new_transition(transition_add_3, c("b"), "b")
+              )
+            )
+          ),
+          trajectories = list(
+            new_trajectory(empty_trajectory_fn, c("c"), "c")
+          ),
+          steps = 1,
+          random_seed = 12
         )
     )
 }
@@ -61,7 +90,7 @@ test_that("Single Hazard fn/param, single transition fn/param", {
     
     parms$steps = 4
     step4 = run_simulation(initPop, parms)
-    expect_equal(step4$a, ret_test)
+    expect_equal(step4$a, ret_test * 4)
     
     # Validate that returned data tables are type data.table
     expect_true(data.table::is.data.table(step1))
@@ -70,17 +99,39 @@ test_that("Single Hazard fn/param, single transition fn/param", {
 
 test_that("Single Hazard fn/param, multiple transition fn/param", {
     N = 100
-    initPop <- sample_pop2(N)
-    parms <- get_parms()
+    initPop <- sample_pop3(N)
+    parms <- get_parms2()
+    ## Add second transition
     ## All odd indices "a" parameter transitions from 0 to 2, even remain 0
-    ret_test <- rep(0.0, N)
-    ret_test[seq(2, N, by = 2)] <- 2
+    ret_test1 <- rep(0.0, N)
+    ret_test1[seq(2, N, by = 2)] <- 2
+    ## All odd indices "b" parameter transitions from 0 to 3, even remain 0
+    ret_test2 <- rep(0.0, N)
+    ret_test2[seq(2, N, by = 2)] <- 3
     
     parms$steps = 1
     step1 = run_simulation(initPop, parms)
-    expect_equal(step1$a, ret_test)
+    expect_equal(step1$a, ret_test1)
+    expect_equal(step1$b, ret_test2)
     
     parms$steps = 4
     step4 = run_simulation(initPop, parms)
-    expect_equal(step4$a, ret_test)
+    expect_equal(step4$a, ret_test1 * 4)
+    expect_equal(step4$b, ret_test2 * 4)
+    
+    # Multiple transitions of same hazard share RNG
+    parms$hazards[[1]]$fn = fifty_fifty_hazard
+    parms$random_seed <- 12
+    
+    parms$steps = 1
+    step1 = run_simulation(initPop, parms)
+    expect_equal(step1$a * 1.5, step1$b)
+    
+    parms$steps = 4
+    step4 = run_simulation(initPop, parms)
+    expect_equal(step1$a * 1.5, step1$b)
+    
+    parms$steps = 7
+    step4 = run_simulation(initPop, parms)
+    expect_equal(step1$a * 1.5, step1$b)
 })


### PR DESCRIPTION
Hazard functions do not directly return probability, it should undergo p = 1-exp(-h*dt)

Also only roll random once per hazard, not per individual transition. (messaged @petedodd on Google Chat to confirm that this is intended behaviour).

Updated tests:
- Hazard return `1.0` changed to `1000` to ensure "certainty"
- Added new test for random-per-hazard
- Fixed unfinished hazard with multiple transitions test