### PR TITLE
BugFix: Random test was not updated when timing was merged

### DIFF
--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -35,7 +35,7 @@ test_that("Different random, different hazard results", {
     rng_12 = run_simulation(initPop, parms)
     parms$random_seed = 13
     rng_13 = run_simulation(initPop, parms)
-    expect_false(identical(rng_12, rng_13))
+    expect_false(identical(rng_12["pop"], rng_13["pop"]))
 })
 test_that("Same random, same hazard results", {
     N <- 100
@@ -45,7 +45,7 @@ test_that("Same random, same hazard results", {
     rng_12a = run_simulation(initPop, parms)
     parms$random_seed = 12
     rng_12b = run_simulation(initPop, parms)
-    expect_identical(rng_12a, rng_12b)
+    expect_identical(rng_12a["pop"], rng_12b["pop"])
 })
 test_that("Random==0, different random, different hazard results", {
     N <- 100
@@ -56,7 +56,7 @@ test_that("Random==0, different random, different hazard results", {
     rng_12 = run_simulation(initPop, parms)
     set.seed(13)
     rng_13 = run_simulation(initPop, parms)
-    expect_false(identical(rng_12, rng_13))
+    expect_false(identical(rng_12["pop"], rng_13["pop"]))
 })
 test_that("Random==0, same random, same hazard results", {
     N <- 100
@@ -67,5 +67,5 @@ test_that("Random==0, same random, same hazard results", {
     rng_12a = run_simulation(initPop, parms)
     set.seed(12)
     rng_12b = run_simulation(initPop, parms)
-    expect_identical(rng_12a, rng_12b)
+    expect_identical(rng_12a["pop"], rng_12b["pop"])
 })


### PR DESCRIPTION
Random tests were not updated when timing was added to `run_simulation()` return value.

Test should obviously not compare timing, only results.

Closes #31