### PR TITLE
Initial population must inherit from data.frame

### DIFF
--- a/R/parameters.R
+++ b/R/parameters.R
@@ -3,6 +3,13 @@
 #' @param parameters An golden_parameters S3 object to be validated
 #' @param initPop data.frame which contains the columns required by parameters
 check_parameters <- function(parameters, initPop = NULL) {
+  # initpop must be derived from data.frame (e.g. data.table)
+  if (!is.null(initPop)) {
+    if (!inherits(initPop, "data.frame")) {
+      stop("initPop type must inherit from class data.frame (e.g. data.table)")
+    }
+  }
+
   validate_S3(parameters, "Object", "golden_parameters")
 
   # Are the expected fields present

--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -681,3 +681,33 @@ test_that("No args fn is valid/invalid", {
         "'column\\$args' must not be empty")
 })
 
+
+
+test_that("initPop must inherit from data.frame", {
+  # Basic empty parameters, as we're testing first error
+  prm <- new_parameters(list(), list(), 12, 12, FALSE)
+  # Generic data set
+  N <- 100
+  a <- rep(0, N)
+  b <- rep(0, N)
+  c <- rep(0, N)
+  df <- data.frame(a = a, b = b, c = c)
+  dt <- data.table(a = a, b = b, c = c)
+  lst <- list(a = a, b = b, c = c)
+  mat <- cbind(a, b, c)
+  # data.frame, data.table are fine
+  expect_no_error(check_parameters(prm, df))
+  expect_no_error(check_parameters(prm, dt))
+  # list and matrix are bad
+  expect_error(check_parameters(prm, lst),
+      "must inherit from class data.frame",
+      info = paste("Matrix passed to check_parameters (via run_simulation()) should error."))
+  expect_error(check_parameters(prm, mat),
+      "must inherit from class data.frame",
+      info = paste("Matrix passed to check_parameters (via run_simulation()) should error."))
+  # Adding column names doesn't change that
+  colnames(mat) <- c("a", "b", "c")
+  expect_error(check_parameters(prm, mat),
+      "must inherit from class data.frame",
+      info = paste("Matrix passed to check_parameters (via run_simulation()) should error."))
+})

--- a/tests/testthat/test-history.R
+++ b/tests/testthat/test-history.R
@@ -11,7 +11,7 @@ test_that("History function collects expected data", {
     STEPS = 10
     # Population size to test
     N = 100
-    initPop <- list(
+    initPop <- data.frame(
         "a" = 1:N
         )
     parms <- new_parameters(
@@ -52,7 +52,7 @@ test_that("History function collects expected data with non-1 frequency", {
     N = 100
     # Frequency of history collection
     FREQ = 3
-    initPop <- list(
+    initPop <- data.frame(
         "a" = 1:N
         )
     parms <- new_parameters(
@@ -104,7 +104,7 @@ test_that("Filtered history function collects expected data", {
     STEPS = 10
     # Population size to test
     N = 100
-    initPop <- list(
+    initPop <- data.frame(
         "a" = 1:N
         )
     parms <- new_parameters(


### PR DESCRIPTION
This now prevents raw lists (and matrices) from being passed.

Can tweak it to allow lists once again if preferred.