### PR TITLE
Issue templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug report
+description: Report a problem with flamegpu2
+title: "[Bug]: "
+labels: ["triage required"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+      placeholder:
+    validations:
+      required: true
+  - type: textarea
+    id: to-reproduce
+    attributes:
+      label: To Reproduce
+      description: Steps to reproduce the behaviour. If applicable, provide a small reproducible code example.
+      placeholder: | 
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behaviour
+    attributes:
+      label: Expected Behaviour
+      description: A clear and concise description of what you expected to happen.
+      placeholder:
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        Configuration (please complete the following information):
+  - type: input
+    id: configuration-golden
+    attributes:
+      label: Golden Version
+      description: Golden release or commit hash
+      placeholder: e.g. 1.0, d28ca67
+    validations:
+      required: false
+  - type: input
+    id: configuration-r
+    attributes:
+      label: R Version
+      description: R release or nightly/pre-release tag
+      placeholder: e.g. R 4.5.1, R-devel_2026-01-06_r89280 (nightly/pre-release)
+    validations:
+      required: false
+  - type: input
+    id: configuration-os
+    attributes:
+      label: Operating System
+      description: Operating system type and version
+      placeholder: e.g. Ubuntu 22.04, Windows 11
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Information
+      description: Add any other context about the problem here.
+      placeholder:
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+#  - name: Online Userguide and Documentation
+#    url: CRAN page?
+#    about: Please see the online userguide and documentation
+  - name: Support
+    url: https://github.com/RSE-Sheffield/golden/issues
+    about: Please ask (and answer) questions here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature request
+description: Suggest an idea for Golden
+title: "[FeatureReq]: "
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem?
+      description: A clear and concise description of what the problem is.
+      placeholder: "e.g. I'm always frustrated when [...]"
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: "Describe the solution you'd like"
+      description: A clear and concise description of what you want to happen.
+      placeholder:
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: "Describe alternatives you've considered"
+      description: "A clear and concise description of any alternative solutions or features you've considered"
+      placeholder:
+    validations:
+      required: false
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.
+      placeholder:
+    validations:
+      required: false


### PR DESCRIPTION
Structured forms to elicit the most relevant information in issues. Blank issues are enabled, so people can bypass the forms if they have a weird issue.

On clicking new issue, they're presented a menu e.g.

<img width="1214" height="548" alt="image" src="https://github.com/user-attachments/assets/eb81b5a0-99d9-4950-b60e-c41f77dddb31" />

Then they can click through to the form

<img width="1205" height="721" alt="image" src="https://github.com/user-attachments/assets/43e923ae-dee0-4b06-ac1c-24088b58ce66" />


Relates #1