### PR TITLE
Remove old try/catch exception handling

### DIFF
--- a/src/rcpp_interface.cpp
+++ b/src/rcpp_interface.cpp
@@ -140,7 +140,5 @@ List run_simulation(List initPop, List parameters) {
     }
     // Init and run simulation
     Simulation s(parameters);
-    try {
-    try {
     return s.run(initPop);
 }

--- a/src/rcpp_interface.cpp
+++ b/src/rcpp_interface.cpp
@@ -131,21 +131,16 @@ List create_cohort(List demog, unsigned int N) {
 //' results <- run_simulation(dt, params)
 // [[Rcpp::export]]
 List run_simulation(List initPop, List parameters) {
-    try {
-        // Call golden::check_parameters()
-        {        
-            Environment golden = Environment::namespace_env("golden");
-            Function check_parameters = golden["check_parameters"];
+    // Call golden::check_parameters()
+    {        
+        Environment golden = Environment::namespace_env("golden");
+        Function check_parameters = golden["check_parameters"];
 
-            check_parameters(parameters, initPop);
-        }
-        // Init and run simulation
-        Simulation s(parameters);
-        return s.run(initPop);
-    } catch (std::exception &e) {
-        forward_exception_to_r(e);
-    } catch(...) {
-        ::Rf_error("Unknown C++ exception within run_simulation()"); 
+        check_parameters(parameters, initPop);
     }
-    return List();
+    // Init and run simulation
+    Simulation s(parameters);
+    try {
+    try {
+    return s.run(initPop);
 }


### PR DESCRIPTION
This is an old construct that you probably saw in the Rcpp Gallery, but this is not needed anymore. Any exception from the C++ side, including `Rcpp::stop`, is correctly forwarded to R by Rcpp, no try/catch needed.

[Linking to RcppCore/Rcpp/issues/1247 for tracking]