### PR TITLE
Use ceiling for history frequency calculation

### DIFF
--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -24,7 +24,7 @@ int initHistoryFreq(List parameters) {
 int initHistoryRows(List parameters) {
     List history = parameters.containsElementNamed("history") ? parameters["history"] : R_NilValue;
     if (history.size())
-        return static_cast<int>(parameters["steps"]) / static_cast<int>(history["frequency"]);
+        return static_cast<int>(ceil(static_cast<int>(parameters["steps"]) / static_cast<double>(static_cast<int>(history["frequency"]))));
     return 0;
 }
 


### PR DESCRIPTION
Change integer division to use ceiling function for history frequency. This should resolve a potential out of bounds array access when writing history where steps does not cleanly divide logging frequency.

I *think* this will resolve the memory-leak reported by CRAN, via some pen & paper maths, however I wasn't able to reproduce the valgrind error locally so I'm unable to confirm that.