### PR TITLE
Remove devtools as a dependency of the CI workflows.

### DIFF
--- a/.github/workflows/cran.yml
+++ b/.github/workflows/cran.yml
@@ -48,9 +48,9 @@ jobs:
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
-            devtools
             tinytex
           cache: "always"
+          cache-version: 2
           dependencies: "TRUE"
           
       # Make pdflatex available for R CMD check

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -60,9 +60,9 @@ jobs:
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
-            devtools
             tinytex
           cache: "always"
+          cache-version: 2
           dependencies: "TRUE"
           
       # Make pdflatex available for R CMD check

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,9 +60,9 @@ jobs:
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
-            devtools
             tinytex
           cache: "always"
+          cache-version: 2
           dependencies: "TRUE"
           
       ## Output R version in user


### PR DESCRIPTION
This should make the CI more stable, but will require some CI hammering to iron out any missing packages that aren't handled by our DESCRIPTION