### PR TITLE
smaller pop

### DIFF
--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -181,7 +181,7 @@ One of the arguments for `run_simulation` is the initial population. **golden** 
 
 ```{r}
 ## initial population
-N <- 1e4L # population size
+N <- 1e3L # population size: small for vignette
 pop0 <- data.table(
   id = 1:N,                       # patient ids
   death = rep(-1, N),             # time of death


### PR DESCRIPTION
I had a chat with claude about our CRAN issues and it ultimately suggested using the population size 1e4 may be causing timeouts building the vignette under valgrind, which executes an order of magnitude slower. This sounded plausible, so I changed to 1e3. Worth a resubmit?